### PR TITLE
Add ignore-scripts to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 auto-install-peers=true
 legacy-peer-deps=true
 node-linker=hoisted
+ignore-scripts=true


### PR DESCRIPTION
Enable ignore-scripts in .npmrc to prevent running package lifecycle scripts during installs. Also normalize file ending (add newline at EOF); existing settings (auto-install-peers, legacy-peer-deps, node-linker=hoisted) are unchanged.